### PR TITLE
Fix(GitHubUser): fix query of contribution cell

### DIFF
--- a/src/lib/GitHubUser.ts
+++ b/src/lib/GitHubUser.ts
@@ -45,13 +45,13 @@ export class GitHubUser {
       style: false,
       pre: false
     })
-    const elements = root.querySelectorAll('rect.day')
+    const elements = root.querySelectorAll('rect.ContributionCalendar-day')
 
     const contributions: Contribution[] = []
 
     for (const { attributes } of elements) {
       const { 'data-date': date, 'data-count': count } = attributes
-      if (!date.startsWith(`${year}-`)) continue
+      if (!count || !date || !date.startsWith(`${year}-`)) continue
       contributions.push({
         day: date,
         count: parseInt(count, 10)


### PR DESCRIPTION
## Problem

[![Image from Gyazo](https://i.gyazo.com/bd4fba32b3e8a7785ab6605f43c72016.png)](https://gyazo.com/bd4fba32b3e8a7785ab6605f43c72016)

GitHub changed class name of contribution cell in Profile page's contributions section from `day` to `ContributionCalendar-day` .

In this application, get contributions data from contributions section with html parsing and query selector.
So, affected by class name change, and failed to getting data.

## Solution

Fix query for contribution cell to `rect.ContributionCalendar-day` .
